### PR TITLE
augment line buffer and field buffer length.

### DIFF
--- a/src/acat.c
+++ b/src/acat.c
@@ -20,8 +20,8 @@
     atan(1.0 / (x)) / M_PI
 
 #define HASH_LEN 100
-#define LINE_BUFFER_LEN 300
-#define FIELD_BUFFER_LEN 50
+#define LINE_BUFFER_LEN 4096
+#define FIELD_BUFFER_LEN 512
 
 #ifndef LOCAL_STRUCT /*LOCAL_STRUCT*/
 #define LOCAL_STRUCT


### PR DESCRIPTION
When the field of line too long, this would causing line overflow. I augment the buffer length. 