### PR TITLE
big fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ cd build
 cmake ..
 make
 ```
+Here is a [example](https://github.com/benjaminfang/gcta/blob/fhl_dev/docs/build/gcta_build_steps_linux.sh) building the GCTA on linux.

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ cd build
 cmake ..
 make
 ```
-Here is a [example](https://github.com/benjaminfang/gcta/blob/fhl_dev/docs/build/gcta_build_steps_linux.sh) building the GCTA on linux.
+Here is an [example](https://github.com/jianyangqt/gcta/blob/master/docs/build/gcta_build_steps_linux.sh) building the GCTA on linux.


### PR DESCRIPTION
1, edited README.md, add link to build example file.
2. fix bugs.
    1) Fix Eigen Sparse Matrix calculating error when the matrix is 0 by 0 of function erase_B_and_Z
    
        The error of function erase_B_and_Z only show up when the size of selected snp is 1
        and pJ of this snp is greater than _jma_p_cutoff. And then go to the step
        which remove this snp's data from _B, _B_N, _B_i, _Z etc(function
        erase_B_and_Z), and then the error was triggered.
    
        For example(direct cause of error):
        ```
        SimplicialLDLT<eigenSparseMat> ldlt_B(_B);
        _B_i = ldlt_B.solve(_B_i).eval();
        ```
        if the _B is 0 by 0, then above sentence will induce an error.
        The error look like this in gdb
        ```
        __memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:416
        416         movq    -8(%rsi, %rdx), %rcx
    
        ```
    
    2) Fix error of function slct_entry when selected snp is 0;
    
        If the size of selcted snp is 0 and remained is greater than 0, the
        slct_entry step will going on. But the size of _B_N, _Z_N is 0, and
        which will cause same calculating error of Eigen matrix or vector as
        1). So we need add a new snp to initiate those matrix. We using snp
          among remained snp which have biggest chisq value, and using this
          snp to re-initiate the variable(_B_N, _Z_N etc).
    
    Fang Hailing, Ma Ruilei, Qi Ting
