### PR TITLE
Add fastGWA-GE module to fastGWA module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Angli Xue improved the GSMR module.
 
 Robert Maier improved the GCTA-SBLUP module.
 
+Wujuan Zhong and Judong Shen programmed the fastGWA-GE module. 
+
 Contributions to the development of the methods implemented in GCTA (e.g., GREML methods, COJO, mtCOJO, MLMA-LOCO, fastBAT, fastGWA and fastGWA-GLMM) can be found in the corresponding publications (https://yanglab.westlake.edu.cn/software/gcta/index.html#Overview).
 
 

--- a/include/Covar.h
+++ b/include/Covar.h
@@ -31,8 +31,10 @@ public:
     Covar();
     bool getCommonSampleIndex(const vector<string> &sampleIDs, vector<uint32_t> &keep_index, vector<uint32_t> &covar_index);
     bool hasCovar();
+    bool hasEnvir();  
     bool getCovarXRaw(const vector<string> &sampleIDs, vector<double> &X, vector<uint32_t> &keep_index);
     bool getCovarX(const vector<string> &sampleIDs, vector<double> &X, vector<uint32_t> &keep_index);
+    bool getEnvirX(const vector<string> &sampleIDs, vector<double> &X, vector<uint32_t> &keep_index);  
     bool setCovarMapping(bool is_rcovar, vector<vector<string>> *map_order = NULL);
     const vector<string>& getSampleID() const;
 
@@ -50,6 +52,7 @@ private:
     vector<vector<double>> covar;
     vector<vector<double>> qcovar;
     vector<vector<double>> rcovar;
+    vector<vector<double>> envir;
 };
 
 #endif //gcta2_covar_h

--- a/include/FastFAM.h
+++ b/include/FastFAM.h
@@ -56,7 +56,12 @@ public:
     void calculate_fam(uintptr_t *buf, const vector<uint32_t> &markerIndex);
     void calculate_grammar(uintptr_t *buf, const vector<uint32_t> &markerIndex);
     void calculate_gwa(uintptr_t * geno, const vector<uint32_t> &markerIndex);
+    void calculate_gwa_2df(uintptr_t * geno, const vector<uint32_t> &markerIndex);
+    void calculate_gwa_2df_sandwich(uintptr_t * geno, const vector<uint32_t> &markerIndex);
+    void calculate_mixed_2df(uintptr_t *geno, const vector<uint32_t> &markerIndex);
+    void calculate_mixed_2df_sandwich(uintptr_t *geno, const vector<uint32_t> &markerIndex);
     void output_res(const vector<uint8_t> &isValids, const vector<uint32_t> markerIndex);
+    void output_res_2df(const vector<uint8_t> &isValids, const vector<uint32_t> markerIndex);
 
     //void readGenoSample(uint64_t *buf, int num_marker);
     void genRandY(uint64_t *buf, int num_marker);
@@ -67,9 +72,12 @@ public:
 
     static void readFAM(string filename, SpMat& fam, const vector<string> &ids, vector<uint32_t> &remain_index);
     static double HEreg(vector<double> &Zij, vector<double> &Aij, bool &isSig);
+    static double HEreg(vector<double> &Zij, vector<double> &Aij, bool &isSig, double &pvalue);
     static double HEreg(const Ref<const SpMat> fam, const Ref<const VectorXd> pheno, bool &isSig);
+    static double HEreg(const Ref<const SpMat> fam, const Ref<const VectorXd> pheno, bool &isSig, double &pvalue);
     double MCREML(const Ref<const SpMat> fam, const Ref<const VectorXd> pheno, bool &isSig);
     double spREML(const Ref<const SpMat> fam, const Ref<const VectorXd> pheno, bool &isSig);
+    double spREML_2df(const Ref<const SpMat> fam, const Ref<const VectorXd> pheno, bool &isSig, const double rho, double &logLikelihood);
 
     void conditionCovarReg(Eigen::Ref<VectorXd> pheno);
     void conditionCovarReg(VectorXd &pheno, VectorXd &condPheno);
@@ -100,12 +108,21 @@ private:
     float *af = NULL;
     float *info = NULL;
     bool bOutResAll = false;
+    double *p_geno = NULL; 
+    double *p_interaction = NULL; 
+    float *beta_geno = NULL; 
+    float *beta_interaction = NULL; 
+    float *se_geno = NULL; 
+    float *se_interaction = NULL; 
+    float *cov_geno_interaction = NULL; 
+    float *score_geno = NULL; 
+    float *score_interaction = NULL; 
+    float *score = NULL; 
 
-   
     bool fam_flag;
     MatrixXd H, covar;
     bool covarFlag = false;
-
+    bool has_envir = false; 
     bool bGrammar = false;
     int num_grammar_markers;
     VectorXd Vi_y;
@@ -130,7 +147,10 @@ private:
     SpMat V_inverse;
     vector<double> phenos;
     VectorXd phenoVec;
+    VectorXd envirVec; 
+    VectorXd envirVec_scaled;
     VectorXd rawPhenoVec;
+    double VR_copy;
 
     void inverseFAM(SpMat& fam, double VG, double VR);
     void makeIH(MatrixXd &X);

--- a/include/StatLib.h
+++ b/include/StatLib.h
@@ -21,6 +21,7 @@ using Eigen::VectorXd;
 
 namespace StatLib{
     double pchisqd1(double x);
+    double pchisqd2(double x); 
     double qchisqd1(double x);
 
     double pnorm(double x, bool bLowerTail=false);

--- a/src/StatLib.cpp
+++ b/src/StatLib.cpp
@@ -27,11 +27,20 @@ using namespace boost::math;
 
 namespace StatLib{
     chi_squared dist1(1);
+    chi_squared dist2(2); 
     normal_distribution<> norm_dist(0.0, 1.0);
 
     double pchisqd1(double x){
         if(x > 0 && std::isfinite(x)){
             return cdf(complement(dist1, x));
+        }else{
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+    }
+
+    double pchisqd2(double x){
+        if(x > 0 && std::isfinite(x)){
+            return cdf(complement(dist2, x));
         }else{
             return std::numeric_limits<double>::quiet_NaN();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char *argv[]){
         "--set-list", "--burden",
         "--pfile", "--bpfile", "--mpfile", "--mbpfile", "--model-only", "--load-model", "--seed", "--fastGWA-mlm-binary", "--num-vec", "--trace-exact", "--cv-threshold", "--tao-start",
         "--acat", "--gene-list", "--snp-list", "--min-mac", "--max-maf", "--wind",
+        "--envir", "--optimal-rho", "--noSandwich", "--grid-size",
     };
     map<string, vector<string>> options;
     vector<string> keys;


### PR DESCRIPTION
Dear Zhili and Jian, 

We have proposed a fast and powerful linear mixed models (LMM)-based approach, fastGWA-GE, to test for genotype-environment interaction (GEI) effect and G+GxE joint effect. And we have developed the fastGWA-GE software on top of fastGWA module from gcta package. We have modified the following scripts. We mainly modified the FastFAM.cpp to add the fastGWA-GE module. We are wondering whether the fastGWA-GE module can be merged into the fastGWA module in the gcta package. Thank you very much for considering our pull request! Please let us know if you have any questions or suggestions. 

README.md
include/Covar.h
src/Covar.cpp
include/FastFAM.h
src/FastFAM.cpp
include/StatLib.h
src/StatLib.cpp
src/main.cpp

Thanks,
Wujuan