### PR TITLE
Fix build with gcc-13

### DIFF
--- a/include/Marker.h
+++ b/include/Marker.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <map>
 #include <utility>
+#include <cstdint>
 using std::vector;
 using std::string;
 using std::to_string;

--- a/include/Pheno.h
+++ b/include/Pheno.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <cstdint>
 using std::map;
 using std::vector;
 using std::string;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -31,6 +31,7 @@
 #include <numeric>
 #include <algorithm>
 #include <sstream>
+#include <cstdint>
 
 std::string getHostName();
 std::string getLocalTime();


### PR DESCRIPTION
The new compiler version GCC 13 requires explicitly including the header `<cstdint>` to be able to use types such as `uint8_t`, etc. (see [here](https://gcc.gnu.org/gcc-13/porting_to.html)). Before, these types were available by default when including `<string>`. 

As the code for GCTA was written before this change, building with the new compiler version leads to multiple errors such as
```c
In file included from /work/charite/src/gcta/src/utils.cpp:18:
/work/charite/src/gcta/include/utils.hpp:42:1: error: 'uint64_t' does not name a type
   42 | uint64_t getFileByteSize(FILE * file);
      | ^~~~~~~~
/work/charite/src/gcta/include/utils.hpp:34:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   33 | #include <sstream>
  +++ |+#include <cstdint>
   34 |
```
This pull request fixes these errors by including the `<cstdint>` header where it is needed.
