### PR TITLE
Do not generate a random seed when one is specified via the command line

### DIFF
--- a/main/gwas_simu.cpp
+++ b/main/gwas_simu.cpp
@@ -106,12 +106,11 @@ void gcta::GWAS_simu(string bfile, int simu_num, string qtl_file, int case_num, 
     update_id_map_kp(qtl_name, _snp_name_map, _include);
     
     // Generate QTL effects
-    int Seed = -CommFunc::rand_seed();
     if (hsq > 0.0) {
         int num_gener_qtl_eff = 0;
         for (i = 0; i < qtl_num; i++) {
             if (have_eff[i] == 0) {
-                qtl_eff[i] = StatFunc::gasdev(Seed);
+                qtl_eff[i] = StatFunc::gasdev(seed);
                 num_gener_qtl_eff++;
             }
         }
@@ -167,7 +166,7 @@ void gcta::GWAS_simu(string bfile, int simu_num, string qtl_file, int case_num, 
     for (i = 0; i < simu_num; i++) {
         y[i].resize(_keep.size());
         for (j = 0; j < _keep.size(); j++) {
-            if (hsq < 1.0) y[i][j] = g[j] + sd_e * StatFunc::gasdev(Seed);
+            if (hsq < 1.0) y[i][j] = g[j] + sd_e * StatFunc::gasdev(seed);
             else y[i][j] = g[j];
         }
         if (cc_flag) {


### PR DESCRIPTION
Dear maintainers,

Currently, the `--simu-seed` command line flag does not lead to identical results when running the simulation multiple times. 

As far as I can tell from the code, the intention in `option.cpp` is to use a randomly generated seed as a default.
https://github.com/jianyangqt/gcta/blob/f22c624e6a6ca41577223da01756e58d569169e2/main/option.cpp#L98

With the aforementioned command line flag, that value can then be overwritten with a user-defined value.
https://github.com/jianyangqt/gcta/blob/f22c624e6a6ca41577223da01756e58d569169e2/main/option.cpp#L601-L604

The value stored in `simu_seed` is then passed to `GWAS_simu` as the `seed` argument.
https://github.com/jianyangqt/gcta/blob/f22c624e6a6ca41577223da01756e58d569169e2/main/gwas_simu.cpp#L85

In the current code, this `seed` argument is not used. Instead, a local variable `Seed` (capitalized) is defined and used to inform random number generation. 

This means that the user-specified value will be ignored, and the simulation will be random every time. 

This pull request removes this extra seed generation step, so that the `--simu-seed` can work as intended.
