### PR TITLE
issue with large numbers of GRM parts

### DIFF
--- a/src/GRM.cpp
+++ b/src/GRM.cpp
@@ -1660,7 +1660,7 @@ vector<uint32_t> GRM::divide_parts_mem(uint32_t n_sample, uint32_t num_parts){
     vector<uint32_t> div_parts(parts);
     uint32_t total_num = 0;
     for(int i = 0 ; i < parts - 1; i++){
-        uint32_t cur_n = ceil(n_each_part[i] * x1);
+        uint32_t cur_n = round(n_each_part[i] * x1);
         total_num = cur_n + total_num;
         div_parts[i] = total_num - 1;
     }


### PR DESCRIPTION
This fixes an error running GRMs with large numbers of GRM parts relative to the sample size. Running GRMs with more parts than exp(logn(n_samples)/2) would cause issues with the last few parts, as the sample range for those parts would exceed the number of samples available.

I think this fixes issue #91