### PR TITLE
fix error messages

### DIFF
--- a/src/FastFAM.cpp
+++ b/src/FastFAM.cpp
@@ -3145,6 +3145,37 @@ int FastFAM::registerOption(map<string, vector<string>>& options_in){
     //DEBUG: change to .fastFAM
     options["out"] = options_in["out"][0] + ".fastGWA";
 
+    // Check for genetic data dependency for all fastGWA options
+    vector<string> fastGWA_options = {"--fastGWA", "--fastGWA-mlm", "--fastGWA-mlm-binary", 
+                                      "--fastGWA-mlm-exact", "--fastGWA-lr"};
+    bool has_fastGWA_option = false;
+    for(const string& option : fastGWA_options){
+        if(options_in.find(option) != options_in.end()){
+            has_fastGWA_option = true;
+            break;
+        }
+    }
+    
+    if(has_fastGWA_option){
+        // Check if any genetic data file is provided
+        vector<string> genetic_data_options = {"--bfile", "--bgen", "--mbgen", "--pfile", "--bpfile", "--mpfile", "--mbpfile", "--mbfile"};
+        bool has_genetic_data = false;
+        for(const string& option : genetic_data_options){
+            if(options_in.find(option) != options_in.end()){
+                has_genetic_data = true;
+                break;
+            }
+        }
+        if(!has_genetic_data){
+            LOGGER.e(0, "fastGWA requires genetic data to be specified (e.g., --bfile, --pfile, --bgen, etc.).");
+        }
+
+        // Check if phenotype file is provided (fastGWA almost always needs explicit --pheno)
+        if(options_in.find("--pheno") == options_in.end()){
+            LOGGER.e(0, "fastGWA requires a phenotype file to be specified using --pheno.");
+        }
+    }
+
     string curFlag = "--fastGWA";
     if(options_in.find(curFlag) != options_in.end()){
         processFunctions.push_back("fast_fam");

--- a/src/Geno.cpp
+++ b/src/Geno.cpp
@@ -2352,7 +2352,7 @@ void Geno::getGenoArray_bed(const vector<uint32_t>& raw_marker_index, GenoBuf* g
         bool isEOF = false;
         std::tie(r_buf, isEOF) = asyncBufn->start_read();
         if(isEOF){
-            LOGGER.e(0, "the reading process reached to the end of the BED file but couldn’t finish.");
+            LOGGER.e(0, "the reading process reached to the end of the BED file but couldn't finish.");
         }
         move_geno(r_buf, keepMask64, rawCountSamples[0], gbuf->n_sample, numMarker, geno_buf); 
         asyncBufn->end_read();
@@ -3282,7 +3282,7 @@ void Geno::loop_64block(const vector<uint32_t> &raw_marker_index, vector<functio
 
         LOGGER.d(0, "Process block " + std::to_string(cur_block));
         if(isEOF && cur_block != (cur_num_blocks - 1)){
-            LOGGER.e(0, "the reading process reached to the end of the BED file but couldn’t finish.");
+            LOGGER.e(0, "the reading process reached to the end of the BED file but couldn't finish.");
         }
         //correct the marker read;
         if(cur_block == (cur_num_blocks - 1)){
@@ -3498,6 +3498,13 @@ int Geno::registerOption(map<string, vector<string>>& options_in) {
     addMFileListsOption("mbgen_file", ".bgen", "--mbgen", options_in, options);
     addMFileListsOption("mpgen_file", ".pgen", "--mbpfile", options_in, options);
     addMFileListsOption("mpgen_file", ".pgen", "--mpfile", options_in, options);
+
+    // Check for BGEN dependency on --sample
+    if(options_in.find("--mbgen") != options_in.end() || options_in.find("--bgen") != options_in.end()){
+        if(options_in.find("--sample") == options_in.end()){
+            LOGGER.e(0, "when using BGEN format files (--bgen or --mbgen), the --sample option is required to specify the sample information file.");
+        }
+    }
 
     options_d["min_maf"] = 0.0;
     options_d["max_maf"] = 0.5;


### PR DESCRIPTION
This PR proposes changes that potentially fixes 2 bugs in the error messaging function of GCTA. We have several users reported that when they run GCTA but forget some essential flags (e.g., `--bfile`, `--sample`), GCTA will error out with the wrong error messages (e.g., GCTA will state `invalid option "--mbgen"` even though the missing flag is `--sample`). This is misleading. One such example has been reported here: https://github.com/jianyangqt/gcta/issues/106

With help from Junren (houjunren@westlake.edu.cn) and Cursor, we now understand the reasons for the bugs. There are actually 2 bugs:

1.  The first bug is a general bug in the 2-step procedures that GCTA uses to recognize the input flags. GCTA will first check if the input flags are valid listed in [supported_flagsV2](https://github.com/jianyangqt/gcta/blob/f0ba18da45975febf4f5891c10fd7bd4d471fbdc/src/main.cpp#L82). If not, it will then switch to the old option parser in [main/option.cpp](https://github.com/jianyangqt/gcta/blob/f0ba18da45975febf4f5891c10fd7bd4d471fbdc/main/option.cpp). The problem is, when some of the flags like `--sample` is missing, GCTA will execute the [Geno.cpp](https://github.com/jianyangqt/gcta/blob/f0ba18da45975febf4f5891c10fd7bd4d471fbdc/src/Geno.cpp) first, error out, then switch to the old option parser. Since the old option parser does not recognize flags like `--bgen`, it will give a wrong error message. 

2. Similar to the first bug, the second bug is specific to the fastGWA module. When flags like `--bfile` is missing, GCTA-fastGWA will first try to create a FastGWA object and a Pheno object, as in [src/FastFAM.cpp](https://github.com/jianyangqt/gcta/blob/f0ba18da45975febf4f5891c10fd7bd4d471fbdc/src/FastFAM.cpp). But since no --bfile file is provided, the initialization of the Pheno object will fail, and returns an error message of "no phenotype file found.". 

Both bugs can be fixed by adding early checks for flags/dependencies. Therefore, this PR from Cursor suggests 2 such changes, one for FastFAM.cpp, and one for Geno.cpp. 